### PR TITLE
Control overwriting of bulk data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Files will be placed into the directory structure groupname/{email,files,photos,
 ## Command Line Options
 ```
 usage: yahoo.py [-h] [-ct COOKIE_T] [-cy COOKIE_Y] [-ce COOKIE_E]
-                [-cf COOKIE_FILE] [-e] [-at] [-f] [-i] [-d] [-l] [-c] [-p]
-                [-a] [-m] [--user-agent USER_AGENT] [--start START]
-                [--stop STOP] [--ids IDS [IDS ...]] [-w] [-v] [--colour]
-                [--delay DELAY]
+                [-cf COOKIE_FILE] [-e] [-at] [-f] [-i] [-t] [-tr] [-d] [-l]
+                [-c] [-p] [-a] [-m] [-o] [--user-agent USER_AGENT]
+                [--start START] [--stop STOP] [--ids IDS [IDS ...]] [-w] [-v]
+                [--colour] [--delay DELAY]
                 group
 
 positional arguments:
@@ -87,12 +87,18 @@ What to archive:
   -at, --attachments    Only archive attachments (from attachments list)
   -f, --files           Only archive files
   -i, --photos          Only archive photo galleries
+  -t, --topics          Only archive HTML email and attachments through the
+                        topics API
+  -tr, --topicsWithRaw  Only archive both HTML and raw email and attachments
+                        through the topics API
   -d, --database        Only archive database
   -l, --links           Only archive links
   -c, --calendar        Only archive events
   -p, --polls           Only archive polls
   -a, --about           Only archive general info about the group
   -m, --members         Only archive members
+  -o, --overwrite       Overwrite existing files such as email and database
+                        records
 
 Request Options:
   --user-agent USER_AGENT


### PR DESCRIPTION
Add -o / --overwrite to enable the overwriting of previously collected bulk data
This changes the default to not overwrite which helps when trying to
fetch data that had previously failed retries or when fetching again
where there have been new messages/files since last run